### PR TITLE
Update DOTHUB_LUMO2nirs.m

### DIFF
--- a/LUMO_toolbox/DOTHUB_LUMO2nirs.m
+++ b/LUMO_toolbox/DOTHUB_LUMO2nirs.m
@@ -333,20 +333,22 @@ end
 aux = zeros(length(t),8);
 
 % Convert zero intensity values to noise floor estimate ###################
-if size(d,1) == 1 % i.e., if only one sample
+if size(d,1) == 1 % if only one sample
     mnD = d;
 else
     mnD = mean(d);
 end
 dists_3D = DOTHUB_getSDdists(SD3D);
 SDS_noise = 70; % SD channels greater than this (mm) are deemed to be in the the noise floor
-if sum(d==0,'all') > 0
+n_zeros = sum(d==0,'all');
+if n_zeros > 0
     if max(dists_3D) >= SDS_noise
         noisefloorest = mean(mnD(dists_3D>SDS_noise));
         d(d == 0) = noisefloorest;
-        disp('Warning - noise floor estimate has been assigned to zero intensity values')
+        disp([newline 'Warning - zero intensity values have been converted to noise floor estimate'])
     else
-        disp('Warning - intensity data contain zero values')
+        d(d == 0) = 1e-6;
+        disp([newline 'Warning - zero intensity values have been converted to 1e-6'])
     end
 end
 

--- a/LUMO_toolbox/DOTHUB_LUMO2nirs.m
+++ b/LUMO_toolbox/DOTHUB_LUMO2nirs.m
@@ -65,6 +65,7 @@ function [nirs, nirsFileName, SD3DFileName] = DOTHUB_LUMO2nirs(lumoDIR,layoutFil
 % Also note that the plan is to cap the max channel length in the .json layout files to
 % 60 mm by default, which will trickle down to this conversion.
 % RJC 20200217 - Tidied for GITHUB first commit.
+% EGJ 20200923 - Updated to handle zero intensity values
 % #########################################################################
 
 % #########################################################################
@@ -330,6 +331,24 @@ end
 
 % Define AUX matrix #######################################################
 aux = zeros(length(t),8);
+
+% Convert zero intensity values to noise floor estimate ###################
+if size(d,1) == 1 % i.e., if only one sample
+    mnD = d;
+else
+    mnD = mean(d);
+end
+dists_3D = DOTHUB_getSDdists(SD3D);
+SDS_noise = 70; % SD channels greater than this (mm) are deemed to be in the the noise floor
+if sum(d==0,'all') > 0
+    if max(dists_3D) >= SDS_noise
+        noisefloorest = mean(mnD(dists_3D>SDS_noise));
+        d(d == 0) = noisefloorest;
+        disp('Warning - noise floor estimate has been assigned to zero intensity values')
+    else
+        disp('Warning - intensity data contain zero values')
+    end
+end
 
 % OUTPUT ##################################################################
 nirs.SD = SD;


### PR DESCRIPTION
Added handling of zero-valued intensity values (i.e. they are converted to the noise floor estimate, being the mean of channels with an SD distance greater than or equal to 70 mm. A warning message is displayed if the conversion occurs, or if maximum SD distance is less than 70 mm and the data still contain zero values.