### PR TITLE
add toolbox independent range replacement

### DIFF
--- a/Library/range.m
+++ b/Library/range.m
@@ -1,0 +1,14 @@
+function [y] = range(A)
+
+% This function is a toolbox-independent replacement for range from
+% Statistics and Machine Learning toolbox
+%
+% ########## INPUTS ##########
+% A             : array (vector or multidimensional, see doc min)
+%
+% ########## OUTPUTS ##########
+% y             : a scalar of largest element minus smallet
+%                 (for vector inputs) or a vector (for  
+%                 multidimensional input)
+
+y = max(A) - min(A);


### PR DESCRIPTION
I added a re-implementation of the range function, which replaces.

The downside of this is that it silently replaces an inbuilt function for those who have the toolbox, for a potentially marginally slower version, but this should be negligible.

Alternative is to rename it to a unique name in definition and about 5 files that use it, or just put (max(A)-min(A)) directly in code.