### PR TITLE
Index to address chromophores was missing

### DIFF
--- a/Library/Homer2Hacks/DOTHUB_hmrSSRegressionByChannel.m
+++ b/Library/Homer2Hacks/DOTHUB_hmrSSRegressionByChannel.m
@@ -327,10 +327,10 @@ elseif length(size(y)) == 3 %DC DATA
             if ~any(isnan(ssChan))
                 B = pinv(ssChan)*lChan;
                 tmpReg = lChan - B*ssChan;
-                y_reg(:,i) = tmpReg;
+                y_reg(:,j,i) = tmpReg;
             else
                 disp(['No local short channels found for channel ' num2str(i)]);
-                y_reg(:,i) = lChan;
+                y_reg(:,j,i) = lChan;
             end
         end
         tmpHbT = squeeze(y_reg(:,1,i)) + squeeze(y_reg(:,2,i));


### PR DESCRIPTION
The regressed data was looping on the first index only, instead of doing it for each chromophore.