### PR TITLE
Fixing the reading of landmarks data from newer layout files

### DIFF
--- a/LUMO_toolbox/DOTHUB_LUMO2nirs.m
+++ b/LUMO_toolbox/DOTHUB_LUMO2nirs.m
@@ -302,6 +302,12 @@ else %Assume 3D contents of layout file remains and save as SD3D
             SD3D.Landmarks(i,2) = layoutData.Landmarks(i).y;
             SD3D.Landmarks(i,3) = layoutData.Landmarks(i).z;
         end
+    elseif isfield(layoutData,'landmarks')  % for newer layout files
+        for i = 1:size(layoutData.landmarks,1)
+            SD3D.Landmarks(i,1) = layoutData.landmarks(i).x;
+            SD3D.Landmarks(i,2) = layoutData.landmarks(i).y;
+            SD3D.Landmarks(i,3) = layoutData.landmarks(i).z;
+        end
     end
     SD3DFileName = fullfile(lumoPath, [lumoName '_default.SD3D']);
     fprintf(['Saving SD3D to ' SD3DFileName ' ...\n']);


### PR DESCRIPTION
I have come across an issue where newer versions of layout.json files in .LUMO data do not work with the toolbox. The main issue is that the structure of layout files changed:  the 'Landmarks' field became 'landmarks'. Since MATLAB is case sensitive, the current toolbox version cannot read the layout data properly. I propose a quick change that ignores the letter case and allows to use the toolbox with both older and newer layout files without the need to correct them.