### PR TITLE
Updated .LUMO to .nirs conversion script

### DIFF
--- a/LUMO_toolbox/regexAndReadHardwareFile.m
+++ b/LUMO_toolbox/regexAndReadHardwareFile.m
@@ -1,0 +1,16 @@
+function toml_data = regexAndReadHardwareFile(filename)
+%This function is meant to hardware toml files so that they are
+%readable by matlab-toml.
+%
+%Input should be the same as toml.read
+%
+%This functionality shouldn't be required, but matlab-toml has issues with
+%reading certain valid toml files.
+
+raw_text = fileread(filename);
+
+%Removes indentation within toml files.
+fixed_raw_text = regexprep(raw_text,'[\n\r]+[\t ]+','\n');
+
+toml_data = toml.decode(fixed_raw_text);
+end

--- a/LUMO_toolbox/regexAndReadRecordingDataFile.m
+++ b/LUMO_toolbox/regexAndReadRecordingDataFile.m
@@ -1,0 +1,29 @@
+function toml_data = regexAndReadRecordingDataFile(filename)
+%This function is meant to recordingData toml files so that they are
+%readable by matlab-toml.
+%
+%Input should be the same as toml.read
+%
+%This functionality shouldn't be required, but matlab-toml has issues with
+%reading certain valid toml files.
+
+raw_text = fileread(filename);
+
+%Fixes arrays with new lines and indentation before numbers or opening
+%brackets.
+raw_text = regexprep(raw_text,'[\n\r]+[\t ]+([\d\[])','$1');
+
+%Fixes arrays with newlines before closing bracket.
+raw_text = regexprep(raw_text,'[\n\r]+\]',']');
+
+%Removes spaces between delimiters and numeric elements of an array.
+raw_text = regexprep(raw_text,'([^=]) +(\d+)','$1$2');
+
+%Removes spaces between numeric elements of an array and delimters.
+raw_text = regexprep(raw_text,'(\d+) +([^=])','$1$2');
+
+%Adds spaces between, delimiters and the numeric element that comes after.
+raw_text = regexprep(raw_text,',(.)',', $1');
+
+toml_data = toml.decode(raw_text);
+end


### PR DESCRIPTION
The updated files can be used to read the .LUMO data format that was updated in the LUMOview GUI v1.0.0 version. These files are compatible with both old and new raw .LUMO data formats.

DOTHUB_LUMO2nirs.m has the main code that does the conversion between the .LUMO and .nirs, while the other two files have helper function. 